### PR TITLE
Assert the correct type of the expression bound to the `NgLet` input …

### DIFF
--- a/libs/store/src/lib/directives/ngLet.ts
+++ b/libs/store/src/lib/directives/ngLet.ts
@@ -7,7 +7,7 @@ import {
   OnInit,
 } from '@angular/core';
 
-export class NgLetContext<T> {
+export class NgLetContext<T = any> {
   $implicit: T = null;
   ngLet: T = null;
 }
@@ -15,7 +15,7 @@ export class NgLetContext<T> {
 @Directive({
   selector: '[ngLet]',
 })
-export class NgLetDirective<T> implements OnInit {
+export class NgLetDirective<T = any> implements OnInit {
   private _context: NgLetContext<T> = new NgLetContext<T>();
 
   @Input()

--- a/libs/store/src/lib/directives/ngLet.ts
+++ b/libs/store/src/lib/directives/ngLet.ts
@@ -16,7 +16,7 @@ export class NgLetContext<T> {
   selector: '[ngLet]',
 })
 export class NgLetDirective<T> implements OnInit {
-  private _context: NgLetContext<T> = new NgLetContext();
+  private _context: NgLetContext<T> = new NgLetContext<T>();
 
   @Input()
   set ngLet(value: T) {

--- a/libs/store/src/lib/directives/ngLet.ts
+++ b/libs/store/src/lib/directives/ngLet.ts
@@ -7,29 +7,52 @@ import {
   OnInit,
 } from '@angular/core';
 
-export class NgLetContext {
-  $implicit: any = null;
-  ngLet: any = null;
+export class NgLetContext<T> {
+  $implicit: T = null;
+  ngLet: T = null;
 }
 
 @Directive({
   selector: '[ngLet]',
 })
-export class NgLetDirective implements OnInit {
-  private _context = new NgLetContext();
+export class NgLetDirective<T> implements OnInit {
+  private _context: NgLetContext<T> = new NgLetContext();
 
   @Input()
-  set ngLet(value: any) {
+  set ngLet(value: T) {
     this._context.$implicit = this._context.ngLet = value;
   }
 
   constructor(
     private _vcr: ViewContainerRef,
-    private _templateRef: TemplateRef<NgLetContext>
+    private _templateRef: TemplateRef<NgLetContext<T>>
   ) {}
 
   ngOnInit() {
     this._vcr.createEmbeddedView(this._templateRef, this._context);
+  }
+  
+  /** @internal */
+  public static ngLetUseIfTypeGuard: void;
+
+  /**
+   * Assert the correct type of the expression bound to the `NgLet` input within the template.
+   *
+   * The presence of this static field is a signal to the Ivy template type check compiler that
+   * when the `NgLet` structural directive renders its template, the type of the expression bound
+   * to `NgLet` should be narrowed in some way. For `NgLet`, the binding expression itself is used to
+   * narrow its type, which allows the strictNullChecks feature of TypeScript to work with `NgLet`.
+   */
+  static ngTemplateGuard_ngLet: 'binding';
+
+  /**
+   * Asserts the correct type of the context for the template that `NgLet` will render.
+   *
+   * The presence of this method is a signal to the Ivy template type-check compiler that the
+   * `NgLet` structural directive renders its template with a specific context type.
+   */
+  static ngTemplateContextGuard<T>(dir: NgLetDirective<T>, ctx: any): ctx is NgLetContext<Exclude<T, false | 0 | '' | null | undefined>> {
+    return true;
   }
 }
 


### PR DESCRIPTION
Allow the Ivy template type-check compiler that the `NgLet` structural directive renders its template with a specific context type.